### PR TITLE
fix: Call webpagetest API over https

### DIFF
--- a/src/components/Webpagetests.js
+++ b/src/components/Webpagetests.js
@@ -12,7 +12,7 @@ function createTest({ label, url }) {
 	if (url === null) {
 		return Promise.resolve(null);
 	}
-	const apiUrl = new URL("http://www.webpagetest.org/runtest.php");
+	const apiUrl = new URL("https://www.webpagetest.org/runtest.php");
 	new URLSearchParams({
 		f: "json",
 		k: "A.e2187e86a47779375c33bd84385934e2",

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -27,7 +27,9 @@ export default function Landing() {
 				Webpagetests
 			</Heading>
 			<React.Suspense fallback="loading webpagetests">
-				<Webpagetests />
+				<ErrorBoundary fallback="webpage tests crashed">
+					<Webpagetests />
+				</ErrorBoundary>
 			</React.Suspense>
 		</React.SuspenseList>
 	);


### PR DESCRIPTION
Need to test fetches on deploy previews more thoroughly. Fetching mixed content on localhost is fine but not on prod.